### PR TITLE
fixes mach_override.c for overriding AudioOutputUnitStart() and other functions in Lion (32/64).

### DIFF
--- a/mach_override/mach_override.c
+++ b/mach_override/mach_override.c
@@ -603,6 +603,7 @@ eatKnownInstructions(
 		// if all instruction matches failed, we don't know current instruction then, stop here
 		if (!curInstructionKnown) { 
 			allInstructionsKnown = false;
+			fprintf(stderr, "mach_override: some instructions unknown! Need to update mach_override.c\n");
 			break;
 		}
 		


### PR DESCRIPTION
This addresses overriding such functions as AudioOutputUnitStart() in Lion. There seems to be some double indirection before getting to the actual function.
In 32 bits: jmp .+0x???????? then jmp *0x????????
In 64 bits: jmp .+0x???????? then jmp qword near [rip+0x????????]
The fix works for both 32 and 64 bits.
This could be addressed outside of mach_star, but then it would not be possible to use the MACH_OVERRIDE macro.
There's a test project for checking the AudioOutputUnitStart() overriding, but being new to github, I don't know how to send it yet.

Also, small (potential) bug fix: try making islands executable _before_ planting the jmp.

Regards,
Sylvain Demongeot (author of AccuBeatMix)
