### PR TITLE
fix problem on 32bit Intel for RIP adressing

### DIFF
--- a/mach_inject/mach_inject.c
+++ b/mach_inject/mach_inject.c
@@ -135,8 +135,10 @@ mach_inject(
 #if defined(__x86_64__)
 		imageOffset = 0; // RIP-relative addressing
 #else
-		ASSERT_CAST( void*, remoteCode );
-		imageOffset = ((void*) remoteCode) - image;
+		//ASSERT_CAST( void*, remoteCode );
+		//imageOffset = ((void*) remoteCode) - image;
+		// WARNING: See bug https://github.com/rentzsch/mach_star/issues/11 . Not sure about this.
+		imageOffset = 0;
 #endif
 	}
 	


### PR DESCRIPTION
see bug #11

I'm not sure if you want to merge this already. But this is what works on 10.7, so maybe it is better to have this in right now (with this comment or some other comment) and add some further code later on if there are problems for other people.
