### PR TITLE
Make mach_inject work on PowerPC again

### DIFF
--- a/mach_override/mach_override.c
+++ b/mach_override/mach_override.c
@@ -370,7 +370,10 @@ allocateBranchIsland(
 		err = host_page_size( mach_host_self(), &pageSize );
 		if( !err ) {
 			assert( sizeof( BranchIsland ) <= pageSize );
-#if defined(__x86_64__)
+#if defined(__ppc__) || defined(__POWERPC__)
+			vm_address_t first = 0xfeffffff;
+			vm_address_t last = 0xfe000000 + pageSize;
+#elif defined(__x86_64__)
 			vm_address_t first = (uint64_t)originalFunctionAddress & ~(uint64_t)(((uint64_t)1 << 31) - 1) | ((uint64_t)1 << 31); // start in the middle of the page?
 			vm_address_t last = 0x0;
 #else


### PR DESCRIPTION
Go back to pre-51ae3d199463fa84548f466d649f0821d579fdaf branch islands for PowerPC. Because PowerPC uses ba (branch absolute) to jump to branch islands, the islands must be somewhere in the lowest or highest 32MB of address space.
