### PR TITLE
Fix the compile time warning when building Chromium for 64 bits:

### DIFF
--- a/mach_override/mach_override.c
+++ b/mach_override/mach_override.c
@@ -393,7 +393,7 @@ allocateBranchIsland(
 			vm_address_t first = 0xfeffffff;
 			vm_address_t last = 0xfe000000 + pageSize;
 #elif defined(__x86_64__)
-			vm_address_t first = (uint64_t)originalFunctionAddress & ~(uint64_t)(((uint64_t)1 << 31) - 1) | ((uint64_t)1 << 31); // start in the middle of the page?
+			vm_address_t first = ((uint64_t)originalFunctionAddress & ~(uint64_t)(((uint64_t)1 << 31) - 1)) | ((uint64_t)1 << 31); // start in the middle of the page?
 			vm_address_t last = 0x0;
 #else
 			vm_address_t first = 0xffc00000;


### PR DESCRIPTION
chromium/trunk/src/third_party/mach_override/mach_override.c:374:59:{374:25-374:97}{374:98-374:99}: error: '&' within '|' [-Werror,-Wbitwise-op-parentheses]
                        vm_address_t first = (uint64_t)originalFunctionAddress & ~(uint64_t)(((uint64_t)1 << 31) - 1) | ((uint64_t)1 << 31); // start in the middle of the page?
                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~
chromium/trunk/src/third_party/mach_override/mach_override.c:374:59: note: place parentheses around the '&' expression to silence this warning
